### PR TITLE
refactor: rename skill from notion-cli to notion

### DIFF
--- a/skills/notion/SKILL.md
+++ b/skills/notion/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: notion-cli
+name: notion
 description: Manage Notion pages, databases, and comments from the command line. Search, view, create, and edit content in your Notion workspace.
 allowed-tools: Bash(notion:*), Bash(notion-cli:*)
 ---


### PR DESCRIPTION
Rename the skill directory and frontmatter name from `notion-cli` to `notion` for consistency with other CLI tool skills (e.g. `linear`).