### PR TITLE
fix: use notion-cli command name in skill documentation

### DIFF
--- a/skills/notion/SKILL.md
+++ b/skills/notion/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: notion
 description: Manage Notion pages, databases, and comments from the command line. Search, view, create, and edit content in your Notion workspace.
-allowed-tools: Bash(notion:*), Bash(notion-cli:*)
+allowed-tools: Bash(notion-cli:*)
 ---
 
 # Notion CLI
@@ -10,10 +10,10 @@ A CLI to manage Notion from the command line, using Notion's remote MCP server.
 
 ## Prerequisites
 
-The `notion` command must be available on PATH. To check:
+The `notion-cli` command must be available on PATH. To check:
 
 ```bash
-notion --version
+notion-cli --version
 ```
 
 If not installed:
@@ -29,9 +29,9 @@ Or see: https://github.com/lox/notion-cli
 The CLI uses OAuth authentication. On first use, it opens a browser for authorization:
 
 ```bash
-notion auth login      # Authenticate with Notion
-notion auth status     # Check authentication status
-notion auth logout     # Clear credentials
+notion-cli auth login      # Authenticate with Notion
+notion-cli auth status     # Check authentication status
+notion-cli auth logout     # Clear credentials
 ```
 
 For CI/headless environments, set `NOTION_ACCESS_TOKEN` environment variable.
@@ -39,12 +39,12 @@ For CI/headless environments, set `NOTION_ACCESS_TOKEN` environment variable.
 ## Available Commands
 
 ```
-notion auth            # Manage authentication
-notion page            # Manage pages (list, view, create, upload, edit)
-notion db              # Manage databases (list, query)
-notion search          # Search the workspace
-notion comment         # Manage comments (list, create)
-notion tools           # List available MCP tools
+notion-cli auth            # Manage authentication
+notion-cli page            # Manage pages (list, view, create, upload, edit)
+notion-cli db              # Manage databases (list, query)
+notion-cli search          # Search the workspace
+notion-cli comment         # Manage comments (list, create)
+notion-cli tools           # List available MCP tools
 ```
 
 ## Common Operations
@@ -52,57 +52,57 @@ notion tools           # List available MCP tools
 ### Search
 
 ```bash
-notion search "meeting notes"           # Search workspace
-notion search "project" --limit 5       # Limit results
-notion search "query" --json            # JSON output
+notion-cli search "meeting notes"           # Search workspace
+notion-cli search "project" --limit 5       # Limit results
+notion-cli search "query" --json            # JSON output
 ```
 
 ### Pages
 
 ```bash
 # List pages
-notion page list
-notion page list --limit 10
-notion page list --json
+notion-cli page list
+notion-cli page list --limit 10
+notion-cli page list --json
 
 # View a page (renders as markdown in terminal)
-notion page view <url-or-id>
-notion page view <url> --raw            # Show raw Notion markup
-notion page view <url> --json           # JSON output
+notion-cli page view <url-or-id>
+notion-cli page view <url> --raw            # Show raw Notion markup
+notion-cli page view <url> --json           # JSON output
 
 # Create a page
-notion page create --title "New Page"
-notion page create --title "Doc" --content "# Heading\n\nContent here"
-notion page create --title "Child" --parent <parent-page-id>
+notion-cli page create --title "New Page"
+notion-cli page create --title "Doc" --content "# Heading\n\nContent here"
+notion-cli page create --title "Child" --parent <parent-page-id>
 
 # Upload a markdown file as a page
-notion page upload ./document.md
-notion page upload ./doc.md --title "Custom Title"
-notion page upload ./doc.md --parent "Parent Page Name"
+notion-cli page upload ./document.md
+notion-cli page upload ./doc.md --title "Custom Title"
+notion-cli page upload ./doc.md --parent "Parent Page Name"
 
 # Edit a page
-notion page edit <url> --replace "New content"
-notion page edit <url> --find "old text" --replace-with "new text"
-notion page edit <url> --find "section" --append "additional content"
+notion-cli page edit <url> --replace "New content"
+notion-cli page edit <url> --find "old text" --replace-with "new text"
+notion-cli page edit <url> --find "section" --append "additional content"
 ```
 
 ### Databases
 
 ```bash
-notion db list                          # List databases
-notion db list --json
+notion-cli db list                          # List databases
+notion-cli db list --json
 
-notion db query <database-url-or-id>    # Query a database
-notion db query <id> --json
+notion-cli db query <database-url-or-id>    # Query a database
+notion-cli db query <id> --json
 ```
 
 ### Comments
 
 ```bash
-notion comment list <page-id>           # List comments on a page
-notion comment list <page-id> --json
+notion-cli comment list <page-id>           # List comments on a page
+notion-cli comment list <page-id> --json
 
-notion comment create <page-id> --content "Great work!"
+notion-cli comment create <page-id> --content "Great work!"
 ```
 
 ## Output Formats
@@ -110,14 +110,14 @@ notion comment create <page-id> --content "Great work!"
 Most commands support `--json` for machine-readable output:
 
 ```bash
-notion page list --json | jq '.[0].url'
-notion search "api" --json | jq '.[] | .title'
+notion-cli page list --json | jq '.[0].url'
+notion-cli search "api" --json | jq '.[] | .title'
 ```
 
 ## Tips for Agents
 
-1. **Search first** - Use `notion search` to find pages before operating on them
+1. **Search first** - Use `notion-cli search` to find pages before operating on them
 2. **Use URLs or IDs** - Both work for page/database references
-3. **Check --help** - Every command has detailed help: `notion page edit --help`
+3. **Check --help** - Every command has detailed help: `notion-cli page edit --help`
 4. **Raw output** - Use `--raw` with `page view` to see the original Notion markup
 5. **JSON for parsing** - Use `--json` when you need to extract specific fields


### PR DESCRIPTION
The skill documentation referenced `notion` as the command name, but the actual binary is `notion-cli`. Updated all command examples and the allowed-tools list to use the correct name.