### PR TITLE
feat: default search to workspace-only, add --search-mode flag

### DIFF
--- a/cmd/db.go
+++ b/cmd/db.go
@@ -38,7 +38,7 @@ func runDBList(ctx *Context, query string, limit int) error {
 		searchQuery = "*"
 	}
 
-	resp, err := client.Search(bgCtx, searchQuery)
+	resp, err := client.Search(bgCtx, searchQuery, &mcp.SearchOptions{ContentSearchMode: "workspace_search"})
 	if err != nil {
 		output.PrintError(err)
 		return err

--- a/cmd/page.go
+++ b/cmd/page.go
@@ -45,7 +45,7 @@ func runPageList(ctx *Context, query string, limit int) error {
 		searchQuery = "*"
 	}
 
-	resp, err := client.Search(bgCtx, searchQuery)
+	resp, err := client.Search(bgCtx, searchQuery, &mcp.SearchOptions{ContentSearchMode: "workspace_search"})
 	if err != nil {
 		output.PrintError(err)
 		return err

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -9,24 +9,31 @@ import (
 )
 
 type SearchCmd struct {
-	Query string `arg:"" help:"Search query"`
-	Limit int    `help:"Maximum number of results" short:"l" default:"20"`
-	JSON  bool   `help:"Output as JSON" short:"j"`
+	Query      string `arg:"" help:"Search query"`
+	Limit      int    `help:"Maximum number of results" short:"l" default:"20"`
+	JSON       bool   `help:"Output as JSON" short:"j"`
+	SearchMode string `help:"Search mode: 'workspace' (default) or 'ai' (includes connected sources like Linear, Slack)" short:"m" default:"workspace" enum:"workspace,ai"`
 }
 
 func (c *SearchCmd) Run(ctx *Context) error {
 	ctx.JSON = c.JSON
-	return runSearch(ctx, c.Query, c.Limit)
+	return runSearch(ctx, c.Query, c.Limit, c.SearchMode)
 }
 
-func runSearch(ctx *Context, query string, limit int) error {
+func runSearch(ctx *Context, query string, limit int, searchMode string) error {
 	client, err := cli.RequireClient()
 	if err != nil {
 		return err
 	}
 
+	mode := "workspace_search"
+	if searchMode == "ai" {
+		mode = "ai_search"
+	}
+	opts := &mcp.SearchOptions{ContentSearchMode: mode}
+
 	bgCtx := context.Background()
-	resp, err := client.Search(bgCtx, query)
+	resp, err := client.Search(bgCtx, query, opts)
 	if err != nil {
 		output.PrintError(err)
 		return err

--- a/internal/cli/resolve.go
+++ b/internal/cli/resolve.go
@@ -102,7 +102,7 @@ func LooksLikeID(s string) bool {
 }
 
 func resolvePageByName(ctx context.Context, client *mcp.Client, name string) (string, error) {
-	resp, err := client.Search(ctx, name)
+	resp, err := client.Search(ctx, name, &mcp.SearchOptions{ContentSearchMode: "workspace_search"})
 	if err != nil {
 		return "", err
 	}

--- a/internal/mcp/client.go
+++ b/internal/mcp/client.go
@@ -161,10 +161,18 @@ func (c *Client) ListTools(ctx context.Context) ([]mcp.Tool, error) {
 	return resp.Tools, nil
 }
 
-func (c *Client) Search(ctx context.Context, query string) (*SearchResponse, error) {
-	result, err := c.CallTool(ctx, "notion-search", map[string]any{
+type SearchOptions struct {
+	ContentSearchMode string // "workspace_search" or "ai_search" or "" (auto)
+}
+
+func (c *Client) Search(ctx context.Context, query string, opts *SearchOptions) (*SearchResponse, error) {
+	args := map[string]any{
 		"query": query,
-	})
+	}
+	if opts != nil && opts.ContentSearchMode != "" {
+		args["content_search_mode"] = opts.ContentSearchMode
+	}
+	result, err := c.CallTool(ctx, "notion-search", args)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The Notion MCP search tool defaults to AI search when Notion AI is enabled, which searches across all connected sources (Linear, Slack, Google Drive, etc.). This caused search results to be dominated by Linear tickets rather than Notion pages.

Changes:
- Default all search calls to `workspace_search` mode
- Add `--search-mode=workspace|ai` flag (`-m`) to the `search` command to opt into AI search across connected sources
- Internal callers (`page list`, `db list`, name resolution) always use workspace search