### PR TITLE
Add --json output support to tools command

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,8 @@ notion-cli comment create <page-id> --content "Comment text"
 ### Other
 
 ```bash
+notion-cli tools                               # List available MCP tools
+notion-cli tools --json                        # Output tools as JSON
 notion-cli version                             # Show version
 notion-cli --help                              # Show help
 ```

--- a/cmd/tools.go
+++ b/cmd/tools.go
@@ -8,9 +8,13 @@ import (
 	"github.com/lox/notion-cli/internal/output"
 )
 
-type ToolsCmd struct{}
+type ToolsCmd struct {
+	JSON bool `help:"Output as JSON" short:"j"`
+}
 
 func (c *ToolsCmd) Run(ctx *Context) error {
+	ctx.JSON = c.JSON
+
 	client, err := cli.RequireClient()
 	if err != nil {
 		return err
@@ -22,6 +26,10 @@ func (c *ToolsCmd) Run(ctx *Context) error {
 	if err != nil {
 		output.PrintError(err)
 		return err
+	}
+
+	if c.JSON {
+		return writeJSON(tools)
 	}
 
 	for _, t := range tools {


### PR DESCRIPTION
Adds -j/--json support to notion-cli tools.

Today tools output is human-formatted text, which makes automation brittle because scripts must parse presentation output. This change keeps default output unchanged and adds --json as a non-breaking machine-readable alternative. The JSON payload carries the same fields already shown in text output (name and description), so behavior stays the same for terminal use while becoming easier to consume in scripts and integrations.