### PR TITLE
feat: add --allow-deleting-content flag to page edit

### DIFF
--- a/cmd/page.go
+++ b/cmd/page.go
@@ -307,18 +307,19 @@ func extractEmojiFromTitle(title string) (icon, cleanTitle string) {
 }
 
 type PageEditCmd struct {
-	Page        string `arg:"" help:"Page URL, name, or ID"`
-	Replace     string `help:"Replace entire content with this text" xor:"action"`
-	Find        string `help:"Text to find (use ... for ellipsis)" xor:"action"`
-	ReplaceWith string `help:"Text to replace with (requires --find)" name:"replace-with"`
-	Append      string `help:"Append text after selection (requires --find)" xor:"action"`
+	Page                 string `arg:"" help:"Page URL, name, or ID"`
+	Replace              string `help:"Replace entire content with this text" xor:"action"`
+	Find                 string `help:"Text to find (use ... for ellipsis)" xor:"action"`
+	ReplaceWith          string `help:"Text to replace with (requires --find)" name:"replace-with"`
+	Append               string `help:"Append text after selection (requires --find)" xor:"action"`
+	AllowDeletingContent bool   `help:"Allow deleting child pages/databases when replacing content" name:"allow-deleting-content"`
 }
 
 func (c *PageEditCmd) Run(ctx *Context) error {
-	return runPageEdit(ctx, c.Page, c.Replace, c.Find, c.ReplaceWith, c.Append)
+	return runPageEdit(ctx, c.Page, c.Replace, c.Find, c.ReplaceWith, c.Append, c.AllowDeletingContent)
 }
 
-func runPageEdit(ctx *Context, page, replace, find, replaceWith, appendText string) error {
+func runPageEdit(ctx *Context, page, replace, find, replaceWith, appendText string, allowDeletingContent bool) error {
 	client, err := cli.RequireClient()
 	if err != nil {
 		return err
@@ -343,6 +344,7 @@ func runPageEdit(ctx *Context, page, replace, find, replaceWith, appendText stri
 
 	var req mcp.UpdatePageRequest
 	req.PageID = pageID
+	req.AllowDeletingContent = allowDeletingContent
 
 	switch {
 	case replace != "":

--- a/internal/mcp/client.go
+++ b/internal/mcp/client.go
@@ -321,7 +321,8 @@ type UpdatePageRequest struct {
 	Command string // "replace_content", "replace_content_range", "insert_content_after", "update_properties"
 
 	// For replace_content
-	NewContent string
+	NewContent           string
+	AllowDeletingContent bool
 
 	// For replace_content_range and insert_content_after
 	Selection string
@@ -335,6 +336,10 @@ func (c *Client) UpdatePage(ctx context.Context, req UpdatePageRequest) error {
 	data := map[string]any{
 		"page_id": req.PageID,
 		"command": req.Command,
+	}
+
+	if req.AllowDeletingContent {
+		data["allow_deleting_content"] = true
 	}
 
 	switch req.Command {


### PR DESCRIPTION
When replacing content on pages that contain child pages or databases, the Notion MCP API returns an error. This adds an `--allow-deleting-content` flag to `page edit` that passes `allow_deleting_content: true` to the `notion-update-page` tool, permitting the operation.

### Changes
- Added `AllowDeletingContent` field to `UpdatePageRequest` in `internal/mcp/client.go`
- Added `--allow-deleting-content` CLI flag to `PageEditCmd` in `cmd/page.go`