### PR TITLE
fix: remove incorrect xor grouping on --find and --append flags

### DIFF
--- a/cmd/page.go
+++ b/cmd/page.go
@@ -309,9 +309,9 @@ func extractEmojiFromTitle(title string) (icon, cleanTitle string) {
 type PageEditCmd struct {
 	Page        string `arg:"" help:"Page URL, name, or ID"`
 	Replace     string `help:"Replace entire content with this text" xor:"action"`
-	Find        string `help:"Text to find (use ... for ellipsis)" xor:"action"`
+	Find        string `help:"Text to find (use ... for ellipsis)"`
 	ReplaceWith string `help:"Text to replace with (requires --find)" name:"replace-with"`
-	Append      string `help:"Append text after selection (requires --find)" xor:"action"`
+	Append      string `help:"Append text after selection (requires --find)"`
 }
 
 func (c *PageEditCmd) Run(ctx *Context) error {


### PR DESCRIPTION
## Problem

The `--find` and `--append` flags on `page edit` were in the same `xor:"action"` Kong group as `--replace`. This meant Kong rejected valid flag combinations like `--find` + `--append` (and technically `--find` + `--replace-with` only worked because `--replace-with` was not in the xor group).

## Fix

Remove `xor:"action"` from `--find` and `--append`. Only `--replace` needs to be in the xor group since it is the only truly standalone action. `--find` is a modifier used *with* either `--replace-with` or `--append`.

The `runPageEdit` function already validates correct flag combinations and returns a clear error for invalid ones.

## Related

Partial follow-up to #14 — that PR fixed the `{"data": ...}` envelope wrapping that caused `page_id` and `command` to arrive as `undefined`. This PR fixes the remaining issue where Kong would reject valid `--find`-based flag combinations.