### PR TITLE
feat(tools): add --json output mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,8 @@ notion-cli comment create <page-id> --content "Comment text"
 ### Other
 
 ```bash
+notion-cli tools                               # List available MCP tools
+notion-cli tools --json                        # Output tools as JSON
 notion-cli version                             # Show version
 notion-cli --version                           # Alias for version
 notion-cli -v                                  # Short alias for version

--- a/cmd/tools.go
+++ b/cmd/tools.go
@@ -2,15 +2,27 @@ package cmd
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"io"
+	"os"
 
 	"github.com/lox/notion-cli/internal/cli"
 	"github.com/lox/notion-cli/internal/output"
 )
 
-type ToolsCmd struct{}
+type ToolsCmd struct {
+	JSON bool `help:"Output as JSON" short:"j"`
+}
+
+type toolSummary struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+}
 
 func (c *ToolsCmd) Run(ctx *Context) error {
+	ctx.JSON = c.JSON
+
 	client, err := cli.RequireClient()
 	if err != nil {
 		return err
@@ -24,8 +36,25 @@ func (c *ToolsCmd) Run(ctx *Context) error {
 		return err
 	}
 
+	summaries := make([]toolSummary, len(tools))
+	for i, t := range tools {
+		summaries[i] = toolSummary{Name: t.Name, Description: t.Description}
+	}
+
+	return printTools(os.Stdout, summaries, c.JSON)
+}
+
+func printTools(w io.Writer, tools []toolSummary, asJSON bool) error {
+	if asJSON {
+		enc := json.NewEncoder(w)
+		enc.SetIndent("", "  ")
+		return enc.Encode(tools)
+	}
+
 	for _, t := range tools {
-		fmt.Printf("%s\n  %s\n\n", t.Name, t.Description)
+		if _, err := fmt.Fprintf(w, "%s\n  %s\n\n", t.Name, t.Description); err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/cmd/tools_test.go
+++ b/cmd/tools_test.go
@@ -1,0 +1,37 @@
+package cmd
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestPrintToolsText(t *testing.T) {
+	var buf bytes.Buffer
+	err := printTools(&buf, []toolSummary{
+		{Name: "notion-search", Description: "Search Notion content"},
+		{Name: "notion-fetch", Description: "Fetch a page or database"},
+	}, false)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	want := "notion-search\n  Search Notion content\n\nnotion-fetch\n  Fetch a page or database\n\n"
+	if buf.String() != want {
+		t.Fatalf("printTools() text output mismatch\nwant:\n%q\ngot:\n%q", want, buf.String())
+	}
+}
+
+func TestPrintToolsJSON(t *testing.T) {
+	var buf bytes.Buffer
+	err := printTools(&buf, []toolSummary{
+		{Name: "notion-search", Description: "Search Notion content"},
+	}, true)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	want := "[\n  {\n    \"name\": \"notion-search\",\n    \"description\": \"Search Notion content\"\n  }\n]\n"
+	if buf.String() != want {
+		t.Fatalf("printTools() JSON output mismatch\nwant:\n%q\ngot:\n%q", want, buf.String())
+	}
+}


### PR DESCRIPTION
## Summary
- add `-j`/`--json` to `notion-cli tools`
- keep default human-readable output unchanged
- emit a stable JSON array with `name` and `description`
- add unit tests for text and JSON output modes
- document both `tools` examples in the README

## Validation
- `mise run test`
- `mise run lint`

Supersedes #18.
