### PR TITLE
feat(page): add --prop and --allow-deleting-content

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,8 +85,10 @@ notion-cli page sync ./document.md --parent-db <db-id>      # Sync as database e
 
 # Edit an existing page
 notion-cli page edit <url> --replace "New content"                      # Replace all content
+notion-cli page edit <url> --replace "New content" --allow-deleting-content # Allow replacing pages with child content
 notion-cli page edit <url> --find "old text" --replace-with "new text"  # Find and replace
 notion-cli page edit <url> --find "section" --append "extra content"    # Append after match
+notion-cli page edit <url> -P "Status=Done" -P "Priority=1"             # Update page properties
 ```
 
 ### Search

--- a/cmd/page.go
+++ b/cmd/page.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -328,18 +329,20 @@ func extractEmojiFromTitle(title string) (icon, cleanTitle string) {
 }
 
 type PageEditCmd struct {
-	Page        string `arg:"" help:"Page URL, name, or ID"`
-	Replace     string `help:"Replace entire content with this text"`
-	Find        string `help:"Text to find (use ... for ellipsis)"`
-	ReplaceWith string `help:"Text to replace with (requires --find)" name:"replace-with"`
-	Append      string `help:"Append text after selection (requires --find)"`
+	Page                 string   `arg:"" help:"Page URL, name, or ID"`
+	Replace              string   `help:"Replace entire content with this text"`
+	Find                 string   `help:"Text to find (use ... for ellipsis)"`
+	ReplaceWith          string   `help:"Text to replace with (requires --find)" name:"replace-with"`
+	Append               string   `help:"Append text after selection (requires --find)"`
+	Prop                 []string `help:"Set page properties (key=value, repeatable)" short:"P"`
+	AllowDeletingContent bool     `help:"Allow deleting child pages/databases when replacing content" name:"allow-deleting-content"`
 }
 
 func (c *PageEditCmd) Run(ctx *Context) error {
-	return runPageEdit(ctx, c.Page, c.Replace, c.Find, c.ReplaceWith, c.Append)
+	return runPageEdit(ctx, c.Page, c.Replace, c.Find, c.ReplaceWith, c.Append, c.Prop, c.AllowDeletingContent)
 }
 
-func runPageEdit(ctx *Context, page, replace, find, replaceWith, appendText string) error {
+func runPageEdit(ctx *Context, page, replace, find, replaceWith, appendText string, props []string, allowDeletingContent bool) error {
 	client, err := cli.RequireClient()
 	if err != nil {
 		return err
@@ -362,7 +365,7 @@ func runPageEdit(ctx *Context, page, replace, find, replaceWith, appendText stri
 		pageID = ref.ID
 	}
 
-	req, err := buildPageEditRequest(replace, find, replaceWith, appendText)
+	req, err := buildPageEditRequest(replace, find, replaceWith, appendText, props, allowDeletingContent)
 	if err != nil {
 		output.PrintError(err)
 		return err
@@ -378,9 +381,32 @@ func runPageEdit(ctx *Context, page, replace, find, replaceWith, appendText stri
 	return nil
 }
 
-func buildPageEditRequest(replace, find, replaceWith, appendText string) (mcp.UpdatePageRequest, error) {
+func buildPageEditRequest(replace, find, replaceWith, appendText string, props []string, allowDeletingContent bool) (mcp.UpdatePageRequest, error) {
+	if allowDeletingContent && replace == "" {
+		return mcp.UpdatePageRequest{}, &output.UserError{Message: "--allow-deleting-content requires --replace"}
+	}
+
+	if len(props) > 0 {
+		if allowDeletingContent {
+			return mcp.UpdatePageRequest{}, &output.UserError{Message: "--allow-deleting-content requires --replace"}
+		}
+		if replace != "" || find != "" || replaceWith != "" || appendText != "" {
+			return mcp.UpdatePageRequest{}, &output.UserError{Message: "--prop cannot be combined with --replace, --find, --replace-with, or --append"}
+		}
+
+		properties, err := parsePageEditProperties(props)
+		if err != nil {
+			return mcp.UpdatePageRequest{}, err
+		}
+
+		return mcp.UpdatePageRequest{
+			Command:    "update_properties",
+			Properties: properties,
+		}, nil
+	}
+
 	if replace == "" && find == "" && replaceWith == "" && appendText == "" {
-		return mcp.UpdatePageRequest{}, &output.UserError{Message: "specify --replace, or --find with --replace-with or --append"}
+		return mcp.UpdatePageRequest{}, &output.UserError{Message: "specify --replace, --prop, or --find with --replace-with or --append"}
 	}
 
 	if replace != "" {
@@ -388,8 +414,9 @@ func buildPageEditRequest(replace, find, replaceWith, appendText string) (mcp.Up
 			return mcp.UpdatePageRequest{}, &output.UserError{Message: "--replace cannot be combined with --find, --replace-with, or --append"}
 		}
 		return mcp.UpdatePageRequest{
-			Command:    "replace_content",
-			NewContent: replace,
+			Command:              "replace_content",
+			NewContent:           replace,
+			AllowDeletingContent: allowDeletingContent,
 		}, nil
 	}
 
@@ -397,7 +424,7 @@ func buildPageEditRequest(replace, find, replaceWith, appendText string) (mcp.Up
 		if replaceWith != "" || appendText != "" {
 			return mcp.UpdatePageRequest{}, &output.UserError{Message: "--replace-with and --append require --find"}
 		}
-		return mcp.UpdatePageRequest{}, &output.UserError{Message: "specify --replace, or --find with --replace-with or --append"}
+		return mcp.UpdatePageRequest{}, &output.UserError{Message: "specify --replace, --prop, or --find with --replace-with or --append"}
 	}
 
 	hasReplace := replaceWith != ""
@@ -420,6 +447,27 @@ func buildPageEditRequest(replace, find, replaceWith, appendText string) (mcp.Up
 			{OldStr: find, NewStr: replaceWith},
 		},
 	}, nil
+}
+
+func parsePageEditProperties(props []string) (map[string]any, error) {
+	properties := make(map[string]any, len(props))
+	for _, p := range props {
+		k, v, ok := strings.Cut(p, "=")
+		if !ok || strings.TrimSpace(k) == "" {
+			return nil, &output.UserError{Message: "invalid property format (expected key=value): " + p}
+		}
+
+		k = strings.TrimSpace(k)
+		var parsed any
+		if err := json.Unmarshal([]byte(v), &parsed); err == nil {
+			properties[k] = parsed
+			continue
+		}
+
+		properties[k] = v
+	}
+
+	return properties, nil
 }
 
 type PageSyncCmd struct {

--- a/cmd/page_edit_test.go
+++ b/cmd/page_edit_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"errors"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -11,7 +12,7 @@ import (
 )
 
 func TestBuildPageEditRequestReplace(t *testing.T) {
-	req, err := buildPageEditRequest("new content", "", "", "")
+	req, err := buildPageEditRequest("new content", "", "", "", nil, false)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
@@ -25,8 +26,23 @@ func TestBuildPageEditRequestReplace(t *testing.T) {
 	}
 }
 
+func TestBuildPageEditRequestReplaceAllowsDeletingContent(t *testing.T) {
+	req, err := buildPageEditRequest("new content", "", "", "", nil, true)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if req.Command != "replace_content" {
+		t.Fatalf("expected replace_content command, got %q", req.Command)
+	}
+
+	if !req.AllowDeletingContent {
+		t.Fatalf("expected allow deleting content to be set")
+	}
+}
+
 func TestBuildPageEditRequestFindReplaceUsesUpdateContent(t *testing.T) {
-	req, err := buildPageEditRequest("", "old text", "new text", "")
+	req, err := buildPageEditRequest("", "old text", "new text", "", nil, false)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
@@ -44,8 +60,32 @@ func TestBuildPageEditRequestFindReplaceUsesUpdateContent(t *testing.T) {
 	}
 }
 
+func TestBuildPageEditRequestPropsUsesUpdateProperties(t *testing.T) {
+	req, err := buildPageEditRequest("", "", "", "", []string{
+		"Status=Done",
+		"Priority=1",
+		"Metadata={\"owner\":\"person@example.com\"}",
+	}, false)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if req.Command != "update_properties" {
+		t.Fatalf("expected update_properties command, got %q", req.Command)
+	}
+
+	want := map[string]any{
+		"Status":   "Done",
+		"Priority": float64(1),
+		"Metadata": map[string]any{"owner": "person@example.com"},
+	}
+	if !reflect.DeepEqual(req.Properties, want) {
+		t.Fatalf("unexpected properties\nwant: %#v\ngot:  %#v", want, req.Properties)
+	}
+}
+
 func TestBuildPageEditRequestFindAppendUsesInsertContentAfter(t *testing.T) {
-	req, err := buildPageEditRequest("", "## Section", "", "\nExtra details")
+	req, err := buildPageEditRequest("", "## Section", "", "\nExtra details", nil, false)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
@@ -69,6 +109,8 @@ func TestBuildPageEditRequestInvalidCombinations(t *testing.T) {
 		find        string
 		replaceWith string
 		appendText  string
+		props       []string
+		allowDelete bool
 	}{
 		{
 			name:        "replace cannot be combined",
@@ -88,6 +130,12 @@ func TestBuildPageEditRequestInvalidCombinations(t *testing.T) {
 			name: "requires an action",
 		},
 		{
+			name:        "allow deleting content requires replace",
+			find:        "old",
+			appendText:  "extra",
+			allowDelete: true,
+		},
+		{
 			name:        "find requires either replace-with or append",
 			find:        "old",
 			replaceWith: "",
@@ -99,11 +147,20 @@ func TestBuildPageEditRequestInvalidCombinations(t *testing.T) {
 			replaceWith: "new",
 			appendText:  "extra",
 		},
+		{
+			name:    "prop cannot be combined",
+			replace: "all",
+			props:   []string{"Status=Done"},
+		},
+		{
+			name:  "invalid prop format",
+			props: []string{"Status"},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if _, err := buildPageEditRequest(tt.replace, tt.find, tt.replaceWith, tt.appendText); err == nil {
+			if _, err := buildPageEditRequest(tt.replace, tt.find, tt.replaceWith, tt.appendText, tt.props, tt.allowDelete); err == nil {
 				t.Fatalf("expected error")
 			}
 		})

--- a/internal/mcp/client.go
+++ b/internal/mcp/client.go
@@ -321,7 +321,8 @@ type UpdatePageRequest struct {
 	Command string // "replace_content", "update_content", "insert_content_after", "update_properties", "apply_template", "update_verification"
 
 	// For replace_content
-	NewContent string
+	NewContent           string
+	AllowDeletingContent bool
 
 	// For update_content
 	ContentUpdates []ContentUpdate
@@ -353,6 +354,9 @@ func buildUpdatePageToolArgs(req UpdatePageRequest) map[string]any {
 	data := map[string]any{
 		"page_id": req.PageID,
 		"command": req.Command,
+	}
+	if req.AllowDeletingContent {
+		data["allow_deleting_content"] = true
 	}
 
 	switch req.Command {

--- a/internal/mcp/update_page_test.go
+++ b/internal/mcp/update_page_test.go
@@ -24,6 +24,27 @@ func TestBuildUpdatePageToolArgsReplaceContent(t *testing.T) {
 	}
 }
 
+func TestBuildUpdatePageToolArgsReplaceContentAllowDeletingContent(t *testing.T) {
+	req := UpdatePageRequest{
+		PageID:               "page-123",
+		Command:              "replace_content",
+		NewContent:           "hello",
+		AllowDeletingContent: true,
+	}
+
+	got := buildUpdatePageToolArgs(req)
+	want := map[string]any{
+		"page_id":                "page-123",
+		"command":                "replace_content",
+		"new_str":                "hello",
+		"allow_deleting_content": true,
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("unexpected args\nwant: %#v\ngot:  %#v", want, got)
+	}
+}
+
 func TestBuildUpdatePageToolArgsUpdateContent(t *testing.T) {
 	req := UpdatePageRequest{
 		PageID:  "page-123",


### PR DESCRIPTION
## Summary
- add `-P`/`--prop` to `page edit` for `update_properties` operations
- parse property values as JSON when valid, otherwise send them as plain strings
- add `--allow-deleting-content` to `page edit --replace` and pass through `allow_deleting_content` to Notion MCP
- validate incompatible flag combinations and keep error messages explicit
- add tests for request building and MCP arg generation
- document the new page-edit examples in the README

## Validation
- `mise run test`
- `mise run lint`

Supersedes #19 and #20.
