### PR TITLE
feat(page): add page archive command

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ notion-cli page view <page> --json             # Output as JSON
 notion-cli page create --title "Title"         # Create a page
 notion-cli page create --title "T" --content "Body text"
 notion-cli page create --title "T" --parent <page-id>
+notion-cli page archive <page-url-or-id>       # Archive a page via the official API
 
 # Upload a markdown file as a new page
 notion-cli page upload ./document.md                        # Title from # heading or filename
@@ -102,6 +103,8 @@ notion-cli page edit <page> -P "Status=Done" -P "Priority=1"             # Updat
 ```
 
 The `<page>` argument accepts a URL, ID, or page name.
+
+`page archive` accepts a page URL or page ID and moves that page to trash via the official API. This requires an official API token configured through `auth api setup` or `NOTION_API_TOKEN`.
 
 `page view` shows open page-level comments and inline block discussions by default. Inline discussions are rendered in context, with the anchor text wrapped in `[[...]]` and the discussion shown immediately below it. Use `--no-comments` to suppress comments, `--raw` to inspect the original Notion markup, and `--json` to return the page plus a `Comments` array.
 

--- a/cmd/page.go
+++ b/cmd/page.go
@@ -14,12 +14,13 @@ import (
 )
 
 type PageCmd struct {
-	List   PageListCmd   `cmd:"" help:"List pages"`
-	View   PageViewCmd   `cmd:"" help:"View a page"`
-	Create PageCreateCmd `cmd:"" help:"Create a page"`
-	Upload PageUploadCmd `cmd:"" help:"Upload a markdown file as a page"`
-	Sync   PageSyncCmd   `cmd:"" help:"Sync a markdown file to a page (create or update)"`
-	Edit   PageEditCmd   `cmd:"" help:"Edit a page"`
+	List    PageListCmd    `cmd:"" help:"List pages"`
+	View    PageViewCmd    `cmd:"" help:"View a page"`
+	Create  PageCreateCmd  `cmd:"" help:"Create a page"`
+	Upload  PageUploadCmd  `cmd:"" help:"Upload a markdown file as a page"`
+	Sync    PageSyncCmd    `cmd:"" help:"Sync a markdown file to a page (create or update)"`
+	Edit    PageEditCmd    `cmd:"" help:"Edit a page"`
+	Archive PageArchiveCmd `cmd:"" help:"Archive a page via the official API"`
 }
 
 var loadPageViewCommentsFn = loadPageViewComments
@@ -382,6 +383,37 @@ type PageEditCmd struct {
 
 func (c *PageEditCmd) Run(ctx *Context) error {
 	return runPageEdit(ctx, c.Page, c.Replace, c.Find, c.ReplaceWith, c.Append, c.Prop, c.AllowDeletingContent)
+}
+
+type PageArchiveCmd struct {
+	Page string `arg:"" help:"Page URL or ID"`
+}
+
+func (c *PageArchiveCmd) Run(ctx *Context) error {
+	return runPageArchive(ctx, c.Page)
+}
+
+func runPageArchive(ctx *Context, page string) error {
+	ref := cli.ParsePageRef(page)
+	if ref.Kind != cli.RefID {
+		err := &output.UserError{Message: "page archive requires a page URL or page ID"}
+		output.PrintError(err)
+		return err
+	}
+
+	apiClient, err := cli.RequireOfficialAPIClient(officialAPIOverrides(ctx))
+	if err != nil {
+		output.PrintError(err)
+		return err
+	}
+
+	if err := apiClient.TrashPage(context.Background(), ref.ID); err != nil {
+		output.PrintError(err)
+		return err
+	}
+
+	output.PrintSuccess("Page archived")
+	return nil
 }
 
 func runPageEdit(ctx *Context, page, replace, find, replaceWith, appendText string, props []string, allowDeletingContent bool) error {

--- a/cmd/page_archive_test.go
+++ b/cmd/page_archive_test.go
@@ -1,0 +1,59 @@
+package cmd
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestRunPageArchiveAcceptsCanonicalIDAndArchives(t *testing.T) {
+	var sawAuthHeader string
+	var sawPath string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sawAuthHeader = r.Header.Get("Authorization")
+		sawPath = r.URL.Path
+
+		if r.Method != http.MethodPatch {
+			t.Fatalf("method = %s, want PATCH", r.Method)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	err := runPageArchive(&Context{
+		APIToken:   "secret-token",
+		APIBaseURL: srv.URL + "/v1",
+	}, "https://www.notion.so/workspace/My-Page-12345678abcdef1234567890abcdef12")
+	if err != nil {
+		t.Fatalf("runPageArchive: %v", err)
+	}
+
+	if sawPath != "/v1/pages/12345678-abcd-ef12-3456-7890abcdef12" {
+		t.Fatalf("path = %q", sawPath)
+	}
+	if sawAuthHeader != "Bearer secret-token" {
+		t.Fatalf("authorization = %q", sawAuthHeader)
+	}
+}
+
+func TestRunPageArchiveRejectsPageName(t *testing.T) {
+	err := runPageArchive(&Context{}, "Meeting Notes")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "page URL or page ID") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRunPageArchiveSurfacesMissingOfficialAPIToken(t *testing.T) {
+	err := runPageArchive(&Context{}, "12345678-abcd-ef12-3456-7890abcdef12")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "run 'notion-cli auth api setup' or set NOTION_API_TOKEN") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/skills/notion/SKILL.md
+++ b/skills/notion/SKILL.md
@@ -100,9 +100,15 @@ notion-cli page sync ./document.md --title "Custom Title"
 notion-cli page edit <page> --replace "New content"
 notion-cli page edit <page> --find "old text" --replace-with "new text"
 notion-cli page edit <page> --find "section" --append "additional content"
+
+# Archive a page
+notion-cli page archive https://notion.so/...
+notion-cli page archive 12345678-abcd-ef12-3456-7890abcdef12
 ```
 
 `page view` shows open page-level comments and inline block discussions by default. Inline discussions are rendered beside their anchor text, with the anchor wrapped in `[[...]]` and the discussion shown immediately below it. Use `--no-comments` when you only want the page body, `--raw` to inspect the original Notion markup, and `--json` when an agent needs the page plus the `Comments` array.
+
+`page archive` uses the official API fallback path and requires `notion-cli auth api setup` or `NOTION_API_TOKEN`.
 
 ### Edit mode guardrails
 


### PR DESCRIPTION
## Summary
- add `page archive` using the official API fallback path
- accept page URLs and page IDs for archive targets
- fail fast with the existing setup guidance when no official API token is configured
- document the new command and auth requirement in the README and bundled skill
- add focused tests for archive success, URL/ID input handling, invalid target input, and missing token behavior

### Usage examples

```bash
notion-cli page archive https://www.notion.so/workspace/My-Page-12345678abcdef1234567890abcdef12  # archive by URL
notion-cli page archive 12345678-abcd-ef12-3456-7890abcdef12                                      # archive by page ID

$ notion-cli page archive https://www.notion.so/workspace/My-Page-12345678abcdef1234567890abcdef12  # no API key configured
✗ create official API client: official API token is required (run 'notion-cli auth api setup' or set NOTION_API_TOKEN)
```

Partial follow-up for #17.

## Validation
- `go build ./...`
- `go test ./...`
- `golangci-lint run`
- local CLI QA against a mock official API:
  - archive by URL returns `✓ Page archived`
  - archive by ID returns `✓ Page archived`
  - requests hit `PATCH /v1/pages/<id>` with `{"in_trash":true}`
