### PR TITLE
fix(auth): warn when api token format looks invalid

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ notion-cli auth status     # Show authentication status
 notion-cli auth logout     # Clear stored credentials
 
 # Official API fallback auth for features MCP cannot handle directly
-notion-cli auth api setup     # Opens the internal integrations page, then prompts for token
+notion-cli auth api setup     # Opens the internal integrations page, prompts for token, warns if format looks wrong
 notion-cli auth api status
 notion-cli auth api verify
 notion-cli auth api unset

--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"regexp"
 	"strings"
 
 	"github.com/fatih/color"
@@ -29,6 +30,7 @@ var authAPIInput io.Reader = os.Stdin
 var authAPIOutput io.Writer = os.Stdout
 var authAPIError io.Writer = os.Stderr
 var openOfficialAPIBrowser = mcp.OpenBrowser
+var notionAPITokenPattern = regexp.MustCompile(`^ntn_[A-Za-z0-9]{20,}$`)
 
 const officialAPIIntegrationsURL = "https://www.notion.so/profile/integrations/internal"
 
@@ -183,6 +185,10 @@ func (c *AuthAPISetupCmd) Run(ctx *Context) error {
 		err := fmt.Errorf("official API token cannot be empty")
 		output.PrintError(err)
 		return err
+	}
+	if !looksLikeNotionAPIToken(token) {
+		output.PrintWarning("Official API token does not match the expected Notion token format")
+		_, _ = fmt.Fprintln(authAPIOutput, "Expected format: ntn_<letters-and-numbers>")
 	}
 	if err := config.SetAPIToken(token); err != nil {
 		output.PrintError(err)
@@ -357,6 +363,10 @@ func readOfficialAPIToken(in io.Reader, out, errOut io.Writer) (string, error) {
 		return "", err
 	}
 	return strings.TrimSpace(line), nil
+}
+
+func looksLikeNotionAPIToken(token string) bool {
+	return notionAPITokenPattern.MatchString(strings.TrimSpace(token))
 }
 
 func printOfficialAPITokenSetupHint(out io.Writer, shouldOpenBrowser bool) {

--- a/cmd/auth_api_test.go
+++ b/cmd/auth_api_test.go
@@ -49,6 +49,25 @@ func TestReadOfficialAPITokenFromReader(t *testing.T) {
 	}
 }
 
+func TestLooksLikeNotionAPIToken(t *testing.T) {
+	valid := "ntn_Q757783358158rIe2zWtQzaPS0AERzY88Mi7HR3KruTbof"
+	if !looksLikeNotionAPIToken(valid) {
+		t.Fatalf("expected valid token format: %q", valid)
+	}
+
+	invalid := []string{
+		"",
+		"secret-token",
+		"ntn-short",
+		"ntn_bad-token",
+	}
+	for _, token := range invalid {
+		if looksLikeNotionAPIToken(token) {
+			t.Fatalf("expected invalid token format: %q", token)
+		}
+	}
+}
+
 func TestPrintOfficialAPITokenSetupHintIncludesURL(t *testing.T) {
 	var out bytes.Buffer
 
@@ -159,6 +178,42 @@ func TestAuthAPIVerifyJSON(t *testing.T) {
 	}
 	if !strings.Contains(out.String(), `"workspace_name": "Workspace"`) {
 		t.Fatalf("unexpected output: %s", out.String())
+	}
+}
+
+func TestAuthAPISetupWarnsWhenTokenFormatLooksWrong(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	var out bytes.Buffer
+	oldIn := authAPIInput
+	oldOut := authAPIOutput
+	authAPIInput = strings.NewReader("not-a-notion-token\n")
+	authAPIOutput = &out
+	t.Cleanup(func() {
+		authAPIInput = oldIn
+		authAPIOutput = oldOut
+	})
+
+	cmd := &AuthAPISetupCmd{}
+	stdout := captureStdout(t, func() {
+		if err := cmd.Run(&Context{}); err != nil {
+			t.Fatalf("Run: %v", err)
+		}
+	})
+
+	if !strings.Contains(stdout, "Official API token does not match the expected Notion token format") {
+		t.Fatalf("expected format warning: %q", stdout)
+	}
+	if !strings.Contains(out.String(), "Expected format: ntn_<letters-and-numbers>") {
+		t.Fatalf("expected token format hint: %q", out.String())
+	}
+
+	loaded, err := config.LoadWithMeta(config.APIOverrides{})
+	if err != nil {
+		t.Fatalf("LoadWithMeta: %v", err)
+	}
+	if loaded.Config.API.Token != "not-a-notion-token" {
+		t.Fatalf("token = %q, want not-a-notion-token", loaded.Config.API.Token)
 	}
 }
 


### PR DESCRIPTION
## Summary
- warn in `auth api setup` when the entered token does not look like a Notion internal integration token
- keep the flow non-blocking so users can still save intentionally unusual tokens
- add regression coverage for the token-format helper and warning path

## Testing
- go test ./cmd/... ./internal/...
