### PR TITLE
fix: relax comment parsing for html bodies

### DIFF
--- a/internal/mcp/client.go
+++ b/internal/mcp/client.go
@@ -574,7 +574,7 @@ func appendCommentBodyText(out *strings.Builder, node *html.Node) {
 		return
 	case html.ElementNode:
 		if node.DataAtom == atom.Br {
-			ensureTrailingCommentNewline(out)
+			out.WriteByte('\n')
 			return
 		}
 		if isCommentBlockNode(node.DataAtom) {
@@ -618,9 +618,12 @@ func normaliseCommentBodyLineEndings(text string) string {
 
 func sanitiseCommentsXML(text string) string {
 	text = strings.NewReplacer(
-		"<br>", "&#10;",
-		"<br/>", "&#10;",
-		"<br />", "&#10;",
+		"<br></br>", "<br/>",
+		"<br ></br>", "<br/>",
+	).Replace(text)
+	text = strings.NewReplacer(
+		"<br>", "<br/>",
+		"<br >", "<br/>",
 	).Replace(text)
 
 	var out strings.Builder

--- a/internal/mcp/client.go
+++ b/internal/mcp/client.go
@@ -13,6 +13,8 @@ import (
 	"github.com/mark3labs/mcp-go/client"
 	"github.com/mark3labs/mcp-go/client/transport"
 	"github.com/mark3labs/mcp-go/mcp"
+	"golang.org/x/net/html"
+	"golang.org/x/net/html/atom"
 )
 
 const (
@@ -475,7 +477,7 @@ type commentXML struct {
 	ID       string `xml:"id,attr"`
 	UserURL  string `xml:"user-url,attr"`
 	Datetime string `xml:"datetime,attr"`
-	Body     string `xml:",chardata"`
+	Body     string `xml:",innerxml"`
 }
 
 func parseCommentsResponse(text string) (*CommentsResponse, error) {
@@ -513,7 +515,7 @@ func parseCommentsXML(text string) (*CommentsResponse, error) {
 	for _, discussion := range doc.Discussions {
 		for _, comment := range discussion.Comments {
 			createdAt, _ := time.Parse(time.RFC3339Nano, comment.Datetime)
-			body := strings.TrimSpace(comment.Body)
+			body := extractCommentBodyText(comment.Body)
 			comments = append(comments, Comment{
 				ID:           comment.ID,
 				Object:       "comment",
@@ -542,7 +544,86 @@ func extractCommentUserID(userURL string) string {
 	return strings.TrimPrefix(userURL, "user://")
 }
 
+func extractCommentBodyText(body string) string {
+	body = strings.TrimSpace(body)
+	if body == "" {
+		return ""
+	}
+
+	nodes, err := html.ParseFragment(strings.NewReader(body), &html.Node{Type: html.ElementNode, DataAtom: atom.Div, Data: "div"})
+	if err != nil {
+		return body
+	}
+
+	var out strings.Builder
+	for _, node := range nodes {
+		appendCommentBodyText(&out, node)
+	}
+
+	return strings.TrimSpace(collapseCommentBodyWhitespace(out.String()))
+}
+
+func appendCommentBodyText(out *strings.Builder, node *html.Node) {
+	if node == nil {
+		return
+	}
+
+	switch node.Type {
+	case html.TextNode:
+		out.WriteString(node.Data)
+		return
+	case html.ElementNode:
+		if node.DataAtom == atom.Br {
+			ensureTrailingCommentNewline(out)
+			return
+		}
+		if isCommentBlockNode(node.DataAtom) {
+			ensureTrailingCommentNewline(out)
+		}
+	}
+
+	for child := node.FirstChild; child != nil; child = child.NextSibling {
+		appendCommentBodyText(out, child)
+	}
+
+	if node.Type == html.ElementNode && isCommentBlockNode(node.DataAtom) {
+		ensureTrailingCommentNewline(out)
+	}
+}
+
+func isCommentBlockNode(tag atom.Atom) bool {
+	switch tag {
+	case atom.P, atom.Div, atom.Li, atom.Ul, atom.Ol, atom.Blockquote:
+		return true
+	default:
+		return false
+	}
+}
+
+func ensureTrailingCommentNewline(out *strings.Builder) {
+	if out.Len() == 0 {
+		return
+	}
+	if strings.HasSuffix(out.String(), "\n") {
+		return
+	}
+	out.WriteByte('\n')
+}
+
+func collapseCommentBodyWhitespace(text string) string {
+	text = strings.ReplaceAll(text, "\r\n", "\n")
+	text = strings.ReplaceAll(text, "\r", "\n")
+	text = regexp.MustCompile(`\n+`).ReplaceAllString(text, "\n")
+	return text
+}
+
 func sanitiseCommentsXML(text string) string {
+	text = strings.NewReplacer(
+		"<br>", "&#10;",
+		"<br/>", "&#10;",
+		"<br />", "&#10;",
+	).Replace(text)
+
 	var out strings.Builder
 	out.Grow(len(text))
 

--- a/internal/mcp/client.go
+++ b/internal/mcp/client.go
@@ -560,7 +560,7 @@ func extractCommentBodyText(body string) string {
 		appendCommentBodyText(&out, node)
 	}
 
-	return strings.TrimSpace(collapseCommentBodyWhitespace(out.String()))
+	return strings.TrimSpace(normaliseCommentBodyLineEndings(out.String()))
 }
 
 func appendCommentBodyText(out *strings.Builder, node *html.Node) {
@@ -610,10 +610,9 @@ func ensureTrailingCommentNewline(out *strings.Builder) {
 	out.WriteByte('\n')
 }
 
-func collapseCommentBodyWhitespace(text string) string {
+func normaliseCommentBodyLineEndings(text string) string {
 	text = strings.ReplaceAll(text, "\r\n", "\n")
 	text = strings.ReplaceAll(text, "\r", "\n")
-	text = regexp.MustCompile(`\n+`).ReplaceAllString(text, "\n")
 	return text
 }
 

--- a/internal/mcp/client.go
+++ b/internal/mcp/client.go
@@ -556,7 +556,10 @@ func extractCommentBodyText(body string) string {
 	}
 
 	var out strings.Builder
-	for _, node := range nodes {
+	for i, node := range nodes {
+		if shouldSkipCommentWhitespaceFragmentNode(nodes, i) {
+			continue
+		}
 		appendCommentBodyText(&out, node)
 	}
 
@@ -570,6 +573,9 @@ func appendCommentBodyText(out *strings.Builder, node *html.Node) {
 
 	switch node.Type {
 	case html.TextNode:
+		if shouldSkipCommentWhitespaceTextNode(node) {
+			return
+		}
 		out.WriteString(node.Data)
 		return
 	case html.ElementNode:
@@ -589,6 +595,66 @@ func appendCommentBodyText(out *strings.Builder, node *html.Node) {
 	if node.Type == html.ElementNode && isCommentBlockNode(node.DataAtom) {
 		ensureTrailingCommentNewline(out)
 	}
+}
+
+func shouldSkipCommentWhitespaceTextNode(node *html.Node) bool {
+	if node == nil || node.Type != html.TextNode || strings.TrimSpace(node.Data) != "" {
+		return false
+	}
+	return isCommentBlockHTMLNode(adjacentNonWhitespaceSibling(node, true)) || isCommentBlockHTMLNode(adjacentNonWhitespaceSibling(node, false))
+}
+
+func shouldSkipCommentWhitespaceFragmentNode(nodes []*html.Node, index int) bool {
+	if index < 0 || index >= len(nodes) {
+		return false
+	}
+	node := nodes[index]
+	if node == nil || node.Type != html.TextNode || strings.TrimSpace(node.Data) != "" {
+		return false
+	}
+	return isCommentBlockHTMLNode(adjacentNonWhitespaceFragmentNode(nodes, index, true)) || isCommentBlockHTMLNode(adjacentNonWhitespaceFragmentNode(nodes, index, false))
+}
+
+func adjacentNonWhitespaceFragmentNode(nodes []*html.Node, index int, previous bool) *html.Node {
+	for i := index + offsetForDirection(previous); i >= 0 && i < len(nodes); i += offsetForDirection(previous) {
+		node := nodes[i]
+		if node == nil {
+			continue
+		}
+		if node.Type == html.TextNode && strings.TrimSpace(node.Data) == "" {
+			continue
+		}
+		return node
+	}
+	return nil
+}
+
+func offsetForDirection(previous bool) int {
+	if previous {
+		return -1
+	}
+	return 1
+}
+
+func adjacentNonWhitespaceSibling(node *html.Node, previous bool) *html.Node {
+	for sibling := siblingNode(node, previous); sibling != nil; sibling = siblingNode(sibling, previous) {
+		if sibling.Type == html.TextNode && strings.TrimSpace(sibling.Data) == "" {
+			continue
+		}
+		return sibling
+	}
+	return nil
+}
+
+func siblingNode(node *html.Node, previous bool) *html.Node {
+	if previous {
+		return node.PrevSibling
+	}
+	return node.NextSibling
+}
+
+func isCommentBlockHTMLNode(node *html.Node) bool {
+	return node != nil && node.Type == html.ElementNode && isCommentBlockNode(node.DataAtom)
 }
 
 func isCommentBlockNode(tag atom.Atom) bool {

--- a/internal/mcp/comments_test.go
+++ b/internal/mcp/comments_test.go
@@ -169,6 +169,18 @@ func TestParseCommentsResponseXMLWrapperWithConsecutiveHTMLLineBreaks(t *testing
 	}
 }
 
+func TestParseCommentsResponseXMLWrapperWithXMLLineBreakPair(t *testing.T) {
+	raw := `{"text":"<discussions total-count=\"1\" shown-count=\"1\"><discussion id=\"discussion://page/block/discussion\" comment-count=\"1\" resolved=\"false\" type=\"comment\" context=\"inline\"><comment id=\"comment-1\" user-url=\"user://user-123\" datetime=\"2026-03-29T22:31:40.086Z\">Hello<br></br>goodbye</comment></discussion></discussions>"}`
+
+	resp, err := parseCommentsResponse(raw)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if got := resp.Comments[0].RichText[0].PlainText; got != "Hello\ngoodbye" {
+		t.Fatalf("expected XML line break pair to be preserved, got %q", got)
+	}
+}
+
 func TestParseCommentsResponseXMLWrapperWithInlineHTMLFormatting(t *testing.T) {
 	raw := `{"text":"<discussions total-count=\"1\" shown-count=\"1\"><discussion id=\"discussion://page/block/discussion\" comment-count=\"1\" resolved=\"false\" type=\"comment\" context=\"inline\"><comment id=\"comment-1\" user-url=\"user://user-123\" datetime=\"2026-03-29T22:31:40.086Z\">Hello <strong>bold</strong> goodbye</comment></discussion></discussions>"}`
 

--- a/internal/mcp/comments_test.go
+++ b/internal/mcp/comments_test.go
@@ -205,6 +205,18 @@ func TestParseCommentsResponseXMLWrapperWithParagraphHTML(t *testing.T) {
 	}
 }
 
+func TestParseCommentsResponseXMLWrapperWithPrettyPrintedParagraphHTML(t *testing.T) {
+	raw := `{"text":"<discussions total-count=\"1\" shown-count=\"1\"><discussion id=\"discussion://page/block/discussion\" comment-count=\"1\" resolved=\"false\" type=\"comment\" context=\"inline\"><comment id=\"comment-1\" user-url=\"user://user-123\" datetime=\"2026-03-29T22:31:40.086Z\"><p>Hello</p>\n<p>goodbye</p></comment></discussion></discussions>"}`
+
+	resp, err := parseCommentsResponse(raw)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if got := resp.Comments[0].RichText[0].PlainText; got != "Hello\ngoodbye" {
+		t.Fatalf("expected pretty-printed paragraph breaks to stay single, got %q", got)
+	}
+}
+
 func TestParseCommentsResponseEmptyObject(t *testing.T) {
 	resp, err := parseCommentsResponse(`{}`)
 	if err != nil {

--- a/internal/mcp/comments_test.go
+++ b/internal/mcp/comments_test.go
@@ -142,6 +142,45 @@ func TestParseCommentsResponseXMLWrapperWithUnknownNamedEntity(t *testing.T) {
 	}
 }
 
+func TestParseCommentsResponseXMLWrapperWithHTMLLineBreak(t *testing.T) {
+	raw := `{"text":"<discussions total-count=\"1\" shown-count=\"1\"><discussion id=\"discussion://page/block/discussion\" comment-count=\"1\" resolved=\"false\" type=\"comment\" context=\"inline\"><comment id=\"comment-1\" user-url=\"user://user-123\" datetime=\"2026-03-29T22:31:40.086Z\">Hello<br>goodbye</comment></discussion></discussions>"}`
+
+	resp, err := parseCommentsResponse(raw)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if len(resp.Comments) != 1 {
+		t.Fatalf("expected 1 comment, got %d", len(resp.Comments))
+	}
+	if got := resp.Comments[0].RichText[0].PlainText; got != "Hello\ngoodbye" {
+		t.Fatalf("expected line break to be preserved, got %q", got)
+	}
+}
+
+func TestParseCommentsResponseXMLWrapperWithInlineHTMLFormatting(t *testing.T) {
+	raw := `{"text":"<discussions total-count=\"1\" shown-count=\"1\"><discussion id=\"discussion://page/block/discussion\" comment-count=\"1\" resolved=\"false\" type=\"comment\" context=\"inline\"><comment id=\"comment-1\" user-url=\"user://user-123\" datetime=\"2026-03-29T22:31:40.086Z\">Hello <strong>bold</strong> goodbye</comment></discussion></discussions>"}`
+
+	resp, err := parseCommentsResponse(raw)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if got := resp.Comments[0].RichText[0].PlainText; got != "Hello bold goodbye" {
+		t.Fatalf("expected inline formatting text to be preserved, got %q", got)
+	}
+}
+
+func TestParseCommentsResponseXMLWrapperWithParagraphHTML(t *testing.T) {
+	raw := `{"text":"<discussions total-count=\"1\" shown-count=\"1\"><discussion id=\"discussion://page/block/discussion\" comment-count=\"1\" resolved=\"false\" type=\"comment\" context=\"inline\"><comment id=\"comment-1\" user-url=\"user://user-123\" datetime=\"2026-03-29T22:31:40.086Z\"><p>Hello</p><p>goodbye</p></comment></discussion></discussions>"}`
+
+	resp, err := parseCommentsResponse(raw)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if got := resp.Comments[0].RichText[0].PlainText; got != "Hello\ngoodbye" {
+		t.Fatalf("expected paragraph breaks to become line breaks, got %q", got)
+	}
+}
+
 func TestParseCommentsResponseEmptyObject(t *testing.T) {
 	resp, err := parseCommentsResponse(`{}`)
 	if err != nil {

--- a/internal/mcp/comments_test.go
+++ b/internal/mcp/comments_test.go
@@ -157,6 +157,18 @@ func TestParseCommentsResponseXMLWrapperWithHTMLLineBreak(t *testing.T) {
 	}
 }
 
+func TestParseCommentsResponseXMLWrapperWithConsecutiveHTMLLineBreaks(t *testing.T) {
+	raw := `{"text":"<discussions total-count=\"1\" shown-count=\"1\"><discussion id=\"discussion://page/block/discussion\" comment-count=\"1\" resolved=\"false\" type=\"comment\" context=\"inline\"><comment id=\"comment-1\" user-url=\"user://user-123\" datetime=\"2026-03-29T22:31:40.086Z\">Hello<br><br>goodbye</comment></discussion></discussions>"}`
+
+	resp, err := parseCommentsResponse(raw)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if got := resp.Comments[0].RichText[0].PlainText; got != "Hello\n\ngoodbye" {
+		t.Fatalf("expected consecutive line breaks to be preserved, got %q", got)
+	}
+}
+
 func TestParseCommentsResponseXMLWrapperWithInlineHTMLFormatting(t *testing.T) {
 	raw := `{"text":"<discussions total-count=\"1\" shown-count=\"1\"><discussion id=\"discussion://page/block/discussion\" comment-count=\"1\" resolved=\"false\" type=\"comment\" context=\"inline\"><comment id=\"comment-1\" user-url=\"user://user-123\" datetime=\"2026-03-29T22:31:40.086Z\">Hello <strong>bold</strong> goodbye</comment></discussion></discussions>"}`
 


### PR DESCRIPTION
## Summary
- relax comment body parsing so page comments with simple HTML markup do not fail or lose text
- preserve inline text inside tags like <strong> and turn paragraph and break markup into newlines
- add regression coverage for <br>, inline formatting, and paragraph markup

## Testing
- go test ./...
- go vet ./...
- golangci-lint run
