### PR TITLE
ci: allow manual CI runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: CI
 
 on:
+  workflow_dispatch:
   pull_request:
   push:
     branches: [main]


### PR DESCRIPTION
## Why

Buildkite UI builds map to `workflow_dispatch`, so the CI workflow is skipped during manual end-to-end testing.

## What

Enable `workflow_dispatch` for CI while preserving the existing push and pull request triggers.
